### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/src/classes/utils/Client/events/window_click.js
+++ b/src/classes/utils/Client/events/window_click.js
@@ -3,7 +3,7 @@ const { inventory } = require('../properties/public/dynamic/inventory.js');
 
 const cursorSlotId = -1; //todo: move to data file
 
-// https://minecraft.fandom.com/wiki/Inventory#Managing_inventory
+// https://minecraft.wiki/w/Inventory#Managing_inventory
 
 module.exports = {
     // window_click({ windowId, slot: clickedSlotId, mouseButton, mode, item: claimedClickedSlot }) {


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.